### PR TITLE
Header: change "Buy POKT" link

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -53,7 +53,7 @@ class Header extends Component {
                 <button className="nav-button" id="account-detail-nav" onClick={() => this.pushToDetails()} >Account Detail</button>
               </StyledLi>
               <StyledLi>
-                <a tartget="_target" href={Config.BUY_POKT_BASE_URL}>Buy POKT</a>
+                <a tartget="_target" href="https://pocketnetwork.typeform.com/to/TC96EJvo">Buy POKT</a>
               </StyledLi>
               <StyledLi>
                 <button className="nav-button" id="log-out-nav" onClick={this.onLogOut} >Log out</button>


### PR DESCRIPTION
Changes the link for buying POKT on the header. Not sure why it was set as an environment variable/config file, but now it's just a hardcoded link.